### PR TITLE
refactor: ルーティングをネストしたRESTful設計に変更

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,19 @@
       "Bash(cat:*)",
       "Bash(bundle install:*)",
       "Bash(bundle exec rspec:*)",
-      "Bash(bundle list:*)"
+      "Bash(bundle list:*)",
+      "Bash(docker compose exec:*)",
+      "Bash(openssl genrsa:*)",
+      "Bash(git log:*)",
+      "Bash(git ls-tree:*)",
+      "Bash(docker compose:*)",
+      "Bash(git push:*)",
+      "Bash(curl -X POST http://localhost:3000/api/v1/auth/login -H \"Content-Type: application/json\" -d '{\n    \"\"\"\"auth\"\"\"\": {\n      \"\"\"\"store_uid\"\"\"\": 210,\n      \"\"\"\"scope\"\"\"\": \"\"\"\"coupon:read coupon:write\"\"\"\"\n    }\n  }')",
+      "Bash(curl -s -X POST http://localhost:3000/api/v1/auth/login -H \"Content-Type: application/json\" -d '{\"\"\"\"auth\"\"\"\":{\"\"\"\"store_uid\"\"\"\":210,\"\"\"\"scope\"\"\"\":\"\"\"\"coupon:read coupon:write\"\"\"\"}}')",
+      "Bash(python3:*)",
+      "Bash(git restore:*)",
+      "WebFetch(domain:ddnexus.github.io)",
+      "Bash(bundle exec rubocop:*)"
     ],
     "deny": [],
     "ask": []

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -4,6 +4,8 @@ module Api
   module V1
     # Coupons API Controller
     class CouponsController < ApplicationController
+      before_action :verify_store_access
+
       def index
         policy = CouponPolicy.new(current_store, Coupon, pundit_policy_context)
         raise Pundit::NotAuthorizedError unless policy.index?
@@ -28,6 +30,11 @@ module Api
       end
 
       private
+
+      def verify_store_access
+        # パスパラメータのstore_idと認証済みstoreの一致を確認
+        raise Pundit::NotAuthorizedError if params[:store_id].to_i != current_store.id
+      end
 
       def coupon_params
         params.require(:coupon).permit(:title, :discount_percentage, :valid_until)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "auth/login", to: "auth#login"
-      resources :coupons, only: [ :index, :create ]
+
+      resources :stores, only: [] do
+        resources :coupons, only: [ :index, :create ]
+      end
     end
   end
 end

--- a/spec/requests/pagination_spec.rb
+++ b/spec/requests/pagination_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "Pagination", type: :request do
     create_list(:coupon, 25, store:)
   end
 
-  describe "GET /api/v1/coupons with pagination" do
+  describe "GET /api/v1/stores/:store_id/coupons with pagination" do
     it "デフォルトで20件を返す" do
-      get "/api/v1/coupons", headers: headers
+      get "/api/v1/stores/#{store.id}/coupons", headers: headers
 
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
@@ -22,7 +22,7 @@ RSpec.describe "Pagination", type: :request do
     end
 
     it "ページネーションメタデータを含む" do
-      get "/api/v1/coupons", headers: headers
+      get "/api/v1/stores/#{store.id}/coupons", headers: headers
 
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
@@ -35,7 +35,7 @@ RSpec.describe "Pagination", type: :request do
     end
 
     it "page パラメータで2ページ目を取得できる" do
-      get "/api/v1/coupons?page=2", headers: headers
+      get "/api/v1/stores/#{store.id}/coupons?page=2", headers: headers
 
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
@@ -44,7 +44,7 @@ RSpec.describe "Pagination", type: :request do
     end
 
     it "limit パラメータで1ページあたりの件数を変更できる" do
-      get "/api/v1/coupons?limit=10", headers: headers
+      get "/api/v1/stores/#{store.id}/coupons?limit=10", headers: headers
 
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
@@ -54,7 +54,7 @@ RSpec.describe "Pagination", type: :request do
     end
 
     it "範囲外のページ番号は最終ページを返す" do
-      get "/api/v1/coupons?page=100", headers: headers
+      get "/api/v1/stores/#{store.id}/coupons?page=100", headers: headers
 
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)


### PR DESCRIPTION
## Summary
- `/api/v1/coupons` → `/api/v1/stores/:store_id/coupons` に変更
- テナント境界チェック（`verify_store_access`）を追加
- 全テストのURLパスを更新し、テナント境界違反のテストケースを追加
- セキュリティ改善: `Coupon.find` → `store.coupons.find`

## 変更理由
- 外部パートナーにも公開するAPIと想定して、RESTful設計と明示的なテナント境界が必要
- ドキュメント（`docs/04_api.md`）との整合性確保

## Test plan
- [x] Rubocop実行（違反なし）
- [x] 全テスト実行（77 examples, 0 failures）
- [x] テナント境界チェックの新規テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)