### PR TITLE
refactor: 不要なコメントを削除とドキュメント整備

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -2,14 +2,12 @@
 
 module Api
   module V1
-    # 認証API Controller
     class AuthController < ApplicationController
       skip_before_action :authenticate_request!, only: [ :login ]
 
       def login
         store = Store.find_by!(id: login_params[:store_uid])
 
-        # JWTトークン発行
         token = JwtService.encode(
           store_uid: store.id,
           scope: login_params[:scope] || "coupon:read coupon:write",

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -2,7 +2,6 @@
 
 module Api
   module V1
-    # Coupons API Controller
     class CouponsController < ApplicationController
       before_action :verify_store_access
 
@@ -10,7 +9,6 @@ module Api
         policy = CouponPolicy.new(current_store, Coupon, pundit_policy_context)
         raise Pundit::NotAuthorizedError unless policy.index?
 
-        # current_storeスコープでクーポンを取得
         coupons = current_store.coupons
         pagy, paginated_coupons = pagy(coupons)
 
@@ -32,14 +30,12 @@ module Api
       private
 
       def verify_store_access
-        # パスパラメータのstore_idと認証済みstoreの一致を確認
         raise Pundit::NotAuthorizedError if params[:store_id].to_i != current_store.id
       end
 
       def coupon_params
         data = params.require(:data)
 
-        # typeの検証
         unless data[:type] == "coupon"
           raise ActionController::BadRequest, "Invalid type: expected 'coupon'"
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,10 @@ class ApplicationController < ActionController::API
   include Pundit::Authorization
   include Pagy::Backend
 
-  # カスタム例外クラス
   class AuthenticationError < StandardError; end
 
   before_action :authenticate_request!
 
-  # エラーハンドリング（JSON:API形式）
   rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found
   rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
   rescue_from Pundit::NotAuthorizedError, with: :handle_forbidden
@@ -48,7 +46,6 @@ class ApplicationController < ActionController::API
     header.split(" ").last
   end
 
-  # JSON:API形式のエラーレスポンスを生成
   def render_error(status:, code:, title:, detail:)
     status_code = Rack::Utils.status_code(status)
     render json: {
@@ -61,7 +58,6 @@ class ApplicationController < ActionController::API
     }, status: status
   end
 
-  # 404 Not Found
   def handle_record_not_found(exception)
     render_error(
       status: :not_found,
@@ -71,7 +67,6 @@ class ApplicationController < ActionController::API
     )
   end
 
-  # 422 Unprocessable Entity
   def handle_record_invalid(exception)
     render_error(
       status: :unprocessable_entity,
@@ -81,7 +76,6 @@ class ApplicationController < ActionController::API
     )
   end
 
-  # 403 Forbidden
   def handle_forbidden(_exception)
     render_error(
       status: :forbidden,
@@ -91,7 +85,6 @@ class ApplicationController < ActionController::API
     )
   end
 
-  # 401 Unauthorized (AuthenticationError)
   def handle_authentication_error(exception)
     render_error(
       status: :unauthorized,
@@ -101,7 +94,6 @@ class ApplicationController < ActionController::API
     )
   end
 
-  # 401 Unauthorized (JWT errors)
   def handle_jwt_error(exception)
     render_error(
       status: :unauthorized,
@@ -111,7 +103,6 @@ class ApplicationController < ActionController::API
     )
   end
 
-  # 400 Bad Request (Parameter Missing)
   def handle_parameter_missing(exception)
     render_error(
       status: :bad_request,
@@ -121,7 +112,6 @@ class ApplicationController < ActionController::API
     )
   end
 
-  # 400 Bad Request (BadRequest)
   def handle_bad_request(exception)
     render_error(
       status: :bad_request,
@@ -131,7 +121,6 @@ class ApplicationController < ActionController::API
     )
   end
 
-  # ページネーションメタデータを生成
   def pagination_meta(pagy)
     {
       current_page: pagy.page,

--- a/app/policies/coupon_policy.rb
+++ b/app/policies/coupon_policy.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-# Couponリソースに対する認可ポリシー
 class CouponPolicy < ApplicationPolicy
-  # 一覧表示の権限
   def index?
-    # 自店舗のクーポンのみアクセス可能
-    # また、coupon:read スコープが必要
     has_scope?("coupon:read")
   end
 
-  # 作成の権限
   def create?
-    # coupon:write スコープが必要
     has_scope?("coupon:write")
   end
 

--- a/app/serializers/coupon_serializer.rb
+++ b/app/serializers/coupon_serializer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Couponリソースのシリアライザ（JSON:API準拠）
 class CouponSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/store_serializer.rb
+++ b/app/serializers/store_serializer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Storeリソースのシリアライザ（JSON:API準拠）
 class StoreSerializer
   include JSONAPI::Serializer
 

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -4,7 +4,6 @@ require "jwt"
 require "openssl"
 require "securerandom"
 
-# JWT発行・検証サービス（RS256署名）
 class JwtService
   ALGORITHM = "RS256"
   CLOCK_SKEW = 60 # 秒
@@ -53,9 +52,8 @@ class JwtService
         iat_leeway: CLOCK_SKEW
       }
 
-      # JWT.decodeは [payload, header] の配列を返す
       decoded = JWT.decode(token, public_key, true, options)
-      decoded[0] # payloadのみ返却
+      decoded[0]
     end
 
     private

--- a/docs/03_database.md
+++ b/docs/03_database.md
@@ -155,11 +155,13 @@ erDiagram
 
 ## 6. 一覧取得と最適化方針
 
-* 既定並び順: `valid_until ASC, id ASC`
+* 既定並び順: **指定なし**（DBのデフォルト順、通常は `id ASC`）
+  * 理由: ユースケースにより最適なソート順が異なるため、API呼び出し側で制御することを想定
+  * 詳細は [DISCUSSION.md](../DISCUSSION.md) の「クーポン一覧のデフォルトソート順」を参照
 * クエリ例
 
-  * 全件: `current_store.coupons.order(valid_until: :asc, id: :asc)`
-  * 有効クーポンのみ: `current_store.coupons.where("valid_until >= ?", Date.current).order(valid_until: :asc, id: :asc)`
+  * 全件: `current_store.coupons`
+  * 有効クーポンのみ: `current_store.coupons.where("valid_until >= ?", Date.current)`
 * インデックス `(store_id, valid_until)` により効率化
 * 頻繁に「有効のみ」を取得する場合、部分インデックスを導入
 


### PR DESCRIPTION
## Summary

- 自明なコメントを削除してコードの可読性を向上
- `docs/03_database.md` のデフォルトソート順記載を実装に合わせて修正

## Changes

### 不要なコメント削除
以下のファイルから自明なコメントを削除：
- `app/controllers/application_controller.rb`
- `app/controllers/api/v1/coupons_controller.rb`
- `app/controllers/api/v1/auth_controller.rb`
- `app/services/jwt_service.rb`
- `app/policies/coupon_policy.rb`
- `app/serializers/coupon_serializer.rb`
- `app/serializers/store_serializer.rb`

削除したコメントの例：
- クラス名を説明するだけのコメント（`# Coupons API Controller`など）
- メソッド名から明らかな処理の説明（`# typeの検証`など）
- HTTPステータスコードを繰り返すコメント（`# 404 Not Found`など）

### ドキュメント修正
`docs/03_database.md` の「6. 一覧取得と最適化方針」セクションを修正：
- 既定並び順: `valid_until ASC, id ASC` → **指定なし**（DBのデフォルト順）
- DISCUSSION.md #8 の決定事項に基づく変更
- クエリ例から `.order()` を削除

## Test plan

- [x] 全テストがパスすることを確認（76 examples, 0 failures）
- [x] DISCUSSION.md #8 の方針と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)